### PR TITLE
Set number steps manually for each variable

### DIFF
--- a/src/components/RightDrawer.vue
+++ b/src/components/RightDrawer.vue
@@ -20,21 +20,23 @@
       ></v-select>
       <v-divider style="margin: 8px 0 8px 0"/>
           {{variable.units}}<v-img contain :src="colormapUrl" />
-      <v-slider v-model="tempMin" :min="variable.vmin" :max="variable.vmax" :step="(variable.vmax-variable.vmin)/100.0" :label="'min ['+variable.units+']'" class="align-center" @end="updateValues()">
+      <v-slider v-model="tempMin" :min="variable.vmin" :max="variable.vmax" :step="variable.step" :label="'min ['+variable.units+']'" class="align-center" @end="updateValues()">
         <template v-slot:append>
           <v-text-field
             v-model="tempMin"
             type="number"
+            :step="variable.step"
             style="width: 80px"
             @change="updateValues()"
           ></v-text-field>
         </template>
       </v-slider>
-      <v-slider v-model="tempMax" :min="variable.vmin" :max="variable.vmax" :step="(variable.vmax-variable.vmin)/100.0" :label="'max ['+variable.units+']'" class="align-center" @end="updateValues()">
+      <v-slider v-model="tempMax" :min="variable.vmin" :max="variable.vmax" :step="variable.step" :label="'max ['+variable.units+']'" class="align-center" @end="updateValues()">
         <template v-slot:append>
           <v-text-field
             v-model="tempMax"
             type="number"
+            :step="variable.step"
             style="width: 80px"
             @change="updateValues()"
           ></v-text-field>

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -17,6 +17,7 @@ export default new Vuex.Store({
         label: 'Salinity',
         vmin: 30,
         vmax: 37,
+        step: 0.1,
         units: 'PSU'
       },
       {
@@ -24,6 +25,7 @@ export default new Vuex.Store({
         label: 'Temperature',
         vmin: -2,
         vmax: 30,
+        step: 0.1,
         units: '°C'
       },
       {
@@ -31,6 +33,7 @@ export default new Vuex.Store({
         label: 'Surface height anomaly',
         vmin: -2,
         vmax: 2,
+        step: 0.05,
         units: 'm'
       },
       /*


### PR DESCRIPTION
Partially fixes https://github.com/sciserver/poseidon-viewer/issues/3
Erasing digits one by one will still cause the value to reset to the min value at some point, so it's best to erase the old value completely first, and then type a new one.